### PR TITLE
Fix InputHandler state persistence

### DIFF
--- a/engine/input/InputHandler.cpp
+++ b/engine/input/InputHandler.cpp
@@ -2,19 +2,17 @@
 #include <iostream>
 
 InputHandler::InputHandler()
-    : rotationX(0.0f), rotationY(0.0f), translationX(0.0f), translationY(0.0f), zoom(1.0f)
+    : rotationX(0.0f), rotationY(0.0f), translationX(0.0f), translationY(0.0f), zoom(1.0f),
+      firstUpdate(true), lastX(0), lastY(0)
 {
 }
 
 void InputHandler::update(int x, int y, bool leftButton, bool rightButton)
 {
-    // Usa variabili statiche per memorizzare la posizione precedente
-    static bool firstCall = true;
-    static int lastX = 0, lastY = 0;
-    if (firstCall) {
+    if (firstUpdate) {
         lastX = x;
         lastY = y;
-        firstCall = false;
+        firstUpdate = false;
     }
     
     int dx = x - lastX;

--- a/engine/input/InputHandler.h
+++ b/engine/input/InputHandler.h
@@ -18,6 +18,10 @@ private:
     float rotationX, rotationY;
     float translationX, translationY;
     float zoom;
+
+    bool firstUpdate;
+    int lastX;
+    int lastY;
 };
 
 #endif // INPUT_HANDLER_H


### PR DESCRIPTION
## Summary
- fix input handler so that previous mouse position is stored per instance

## Testing
- `./build.sh`
- `./run.sh` *(fails: Failed to open X display)*

------
https://chatgpt.com/codex/tasks/task_e_6851dff542bc83278594b1eaa7c781c7